### PR TITLE
Add TutorialSearch to Tutorials

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@
 ## Tutorials
 
 > Awesome tutorials for using GraphQL with Vue
+- [TutorialSearch](https://tutorialsearch.io/) - Free cross-platform search engine indexing 50,000+ tutorials from Udemy, Skillshare, Pluralsight, and other major learning platforms across 45+ categories.
 - VueJS
   - [Vue + Apollo Tutorial](https://learn.hasura.io/graphql/vue)
   - [Getting Started with VueJS](https://medium.freecodecamp.org/a-quick-introduction-to-vue-js-72937ee8880d)

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@
 ## Tutorials
 
 > Awesome tutorials for using GraphQL with Vue
-- [TutorialSearch](https://tutorialsearch.io/) - Free cross-platform search engine indexing 50,000+ tutorials from Udemy, Skillshare, Pluralsight, and other major learning platforms across 45+ categories.
+- [TutorialSearch](https://tutorialsearch.io/browse/programming-languages/javascript-development) - Free cross-platform search engine indexing 50,000+ tutorials from Udemy, Skillshare, Pluralsight, and other major learning platforms across 45+ categories.
 - VueJS
   - [Vue + Apollo Tutorial](https://learn.hasura.io/graphql/vue)
   - [Getting Started with VueJS](https://medium.freecodecamp.org/a-quick-introduction-to-vue-js-72937ee8880d)


### PR DESCRIPTION
Hi! This PR adds **TutorialSearch** to the *Tutorials* section.

### What is TutorialSearch?
[TutorialSearch](https://tutorialsearch.io/browse/programming-languages/javascript-development) is a free, cross-platform search engine that indexes 50,000+ tutorials and courses from major learning platforms (Udemy, Skillshare, Pluralsight, and more) across 45+ categories — including programming, web development, AI/ML, cybersecurity, design, and more. No signup required.

It helps learners compare tutorials side-by-side by rating, price, and reviews before committing to a course, which I think makes it a useful addition to this list.

### Entry added
```
- [TutorialSearch](https://tutorialsearch.io/browse/programming-languages/javascript-development) - Free cross-platform search engine indexing 50,000+ tutorials from Udemy, Skillshare, Pluralsight, and other major learning platforms across 45+ categories.
```

Inserted in alphabetical order within the section. Happy to adjust formatting, description length, or placement if you'd like — just let me know!

Thanks for maintaining this list.